### PR TITLE
Allow access to the entire user’s home directory

### DIFF
--- a/org.omegat.OmegaT.yml
+++ b/org.omegat.OmegaT.yml
@@ -7,7 +7,7 @@ sdk-extensions:
 
 command: run.sh
 finish-args:
-  - --filesystem=xdg-documents
+  - --filesystem=home
   - --socket=x11
   - --share=ipc
   - --share=network


### PR DESCRIPTION
Not everyone stores their projects in `~/Documents`, so let users decide where their projects live.

This fixes #1.